### PR TITLE
Add main entry to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "bugs": {
     "url": "https://github.com/PowerPan/leaflet.nauticscale/issues"
   },
+  "main": "dist/leaflet.nauticscale.js",
   "homepage": "https://github.com/PowerPan/leaflet.nauticscale#readme",
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
Without this field, the package it is not usable with npm and other tools, see https://docs.npmjs.com/cli/v6/configuring-npm/package-json#main.